### PR TITLE
Added ability to create an object on arbitrary MOC

### DIFF
--- a/lib/motion_data_wrapper/model/persistence.rb
+++ b/lib/motion_data_wrapper/model/persistence.rb
@@ -23,7 +23,11 @@ module MotionDataWrapper
         end
       
         def new(attributes={})
-          alloc.initWithEntity(entity_description, insertIntoManagedObjectContext:nil).tap do |model|
+          self.newWithContext(nil, attributes)
+        end        
+
+        def newWithContext(context, attributes={})
+          alloc.initWithEntity(entity_description, insertIntoManagedObjectContext:context).tap do |model|
             model.instance_variable_set('@new_record', true)
             attributes.each do |keyPath, value|
               model.setValue(value, forKey:keyPath)


### PR DESCRIPTION
Hi.

It happens so that motion_data_wrapper doesn't permit working with parented MOCs. Actually it does, but there is no way to create a model instance on any MOC besides AppDelegate's. I've added a method to support this which doesn't break any existing functionality.  Didn't add `createWithContext` though, not sure if this one is really that needed.
