### PR TITLE
undefined local variable or method `take' in REPL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tmp
 .DS_Store
 build
 *.momd
+.repl_history
 
 # YARD artifacts
 .yardoc

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Task.pluck(:assignee_id) # returns array of non-distinct values
 Task.uniq.pluck(:assignee_id) # now the array of id values is distinct
 
 Task.first # First task or nil
-Task.first! # First task or MotionDataWrapper::RecordNotFound exception
+Task.last # Last task or nil
 
 Task.limit(1) # returns one task
 Task.offset(5).limit(1) # grab the 6th task, as an array with one item in it
@@ -113,11 +113,11 @@ scope.limit(...).except(:limit)
 # Daisy Chaining
 Task.where(...).order(...).where(...).offset(10).limit(5).count # Yep, this works!
 Task.where(...).order(...).all # array of the results
+Task.where(...).first! # raises MotionDataWrapper::RecordNotFound exception
 
 # Dynamic Finders
 Task.find_by_status :open # returns the first task with a status of open, or nil
 Task.find_all_by_status :open # returns array containing Tasks matching that status
-
 
 # Search in a specific managed object context
 Task.with_context(bg_ctx).where(...) # searches using a specific context, default is App.delegate.managedObjectContext

--- a/lib/motion_data_wrapper/model/finder_methods.rb
+++ b/lib/motion_data_wrapper/model/finder_methods.rb
@@ -23,7 +23,7 @@ module MotionDataWrapper
 
         # @returns [Model] or nil
         def first
-          take
+          relation.first
         end
 
         # @param [id] id to retrieve record by
@@ -33,21 +33,9 @@ module MotionDataWrapper
           find_by_id!(object_id)
         end
 
-        # @raises [RecordNotFound]
-        # @returns [Model]
-        def first!
-          take!
-        end
-
         # @returns [Model] or nil
         def last
-          relation.last.take
-        end
-
-        # @raises [RecordNotFound]
-        # @returns [Model]
-        def last!
-          relation.last.take!
+          relation.last
         end
 
         # @param [Fixnum]

--- a/lib/motion_data_wrapper/relation/finder_methods.rb
+++ b/lib/motion_data_wrapper/relation/finder_methods.rb
@@ -41,9 +41,21 @@ module MotionDataWrapper
         !empty?
       end
 
+      def first
+        take
+      end
+
+      def first!
+        take!
+      end
+
       def last
         self.fetchOffset = self.count - 1 unless self.count < 1
-        self
+        take
+      end
+
+      def last!
+        last or raise RecordNotFound
       end
 
       def limit(l)

--- a/spec/finders_spec.rb
+++ b/spec/finders_spec.rb
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+describe MotionDataWrapper::Model do
+
+  before do
+    @task = Task.create! title: "Matt"
+  end
+
+  after do
+    clean_core_data
+  end
+
+  describe '#all' do
+
+    before do
+      @task2 = Task.create! title: "Second Task"
+    end
+
+    it "should return 2 tasks" do
+      Task.all.should == [@task, @task2]
+    end
+
+    it "should return 2 records from a relation" do
+      Task.limit(10).all.should == [@task, @task2]
+    end
+  end
+
+  describe '#count' do
+
+    it "should return 1 for the only task" do
+      Task.count.should == 1
+    end
+
+    it "should return 2 when there are 2 tasks" do
+      Task.create!
+      Task.count.should == 2
+    end
+
+    it "should return 0 when there are no matching records" do
+      task_relation_without_matches.count.should == 0
+    end
+  end
+
+  describe '#first' do
+    it "should return the only task" do
+      Task.first.should == @task
+    end
+
+    it "should return 1 task from a relation" do
+      Task.limit(10).first.should == @task
+    end
+
+    it "should return nil if no matching records" do
+      task_relation_without_matches.first.should.be.nil?
+    end
+
+    it "should raise exception if called with bang" do
+      ->{ task_relation_without_matches.first! }.should.raise MotionDataWrapper::RecordNotFound
+    end
+  end
+  
+  describe '#last' do
+    it "should return the only task" do
+      Task.last.should == @task
+    end
+
+    it "should return 1 task from a relation" do
+      Task.limit(10).last.should == @task
+    end
+
+    it "should return nil if no matching records" do
+      task_relation_without_matches.last.should.be.nil?
+    end
+
+    it "should raise exception if called with bang" do
+      ->{ task_relation_without_matches.last! }.should.raise MotionDataWrapper::RecordNotFound
+    end
+  end
+end
+
+def task_relation_without_matches
+  Task.where('title contains[cd] ?', 'no records')
+end


### PR DESCRIPTION
Has anyone else noticed this? When I am in the REPL and I try to call methods like first it errors. 

(main)> Call.first
2013-09-20 16:06:29.788[13831:a0b] finder_methods.rb:126:in `method_missing:': undefined local variable or method`take' for Call:Class (NameError)

same thing if I invoke take directly

(main)> Call.take
2013-09-20 16:45:33.707[13831:a0b] finder_methods.rb:126:in `method_missing:': undefined method`take' for Call:Class (NoMethodError)

but it seems to work when called in the running application? 

This is with latest Rubymotion 2.9 and 5.0 GM.

Thanks,
